### PR TITLE
Fix pointer and keyboard bug

### DIFF
--- a/packages/core/src/input/keyboard/KeyboardManager.ts
+++ b/packages/core/src/input/keyboard/KeyboardManager.ts
@@ -1,4 +1,6 @@
 import { DisorderedArray } from "../../DisorderedArray";
+import { Platform } from "../../Platform";
+import { SystemInfo } from "../../SystemInfo";
 import { Keys } from "../enums/Keys";
 import { IInput } from "../interface/IInput";
 
@@ -74,6 +76,16 @@ export class KeyboardManager implements IInput {
             }
             curFrameUpList.add(codeKey);
             upKeyToFrameCountMap[codeKey] = frameCount;
+            // Because on the mac, the keyup event is not responded to when the meta key is held down,
+            // in order to maintain the correct keystroke record, it is necessary to clear the record
+            // when the meta key is lifted.
+            // link: https://stackoverflow.com/questions/11818637/why-does-javascript-drop-keyup-events-when-the-metakey-is-pressed-on-mac-browser
+            if (SystemInfo.platform === Platform.Mac && (codeKey === Keys.MetaLeft || codeKey === Keys.MetaRight)) {
+              for (let i = 0, len = curFrameHeldDownList.length; i < len; i++) {
+                curHeldDownKeyToIndexMap[curFrameHeldDownList.get(i)] = null;
+              }
+              curFrameHeldDownList.length = 0;
+            }
             break;
           default:
             break;

--- a/packages/core/src/input/pointer/PointerManager.ts
+++ b/packages/core/src/input/pointer/PointerManager.ts
@@ -112,9 +112,9 @@ export class PointerManager implements IInput {
     if (!this._hadListener) {
       const { _htmlCanvas: htmlCanvas, _onPointerEvent: onPointerEvent } = this;
       htmlCanvas.addEventListener("pointerdown", onPointerEvent);
-      htmlCanvas.addEventListener("pointerup", onPointerEvent);
-      htmlCanvas.addEventListener("pointerout", onPointerEvent);
       htmlCanvas.addEventListener("pointermove", onPointerEvent);
+      htmlCanvas.addEventListener("pointerup", onPointerEvent);
+      htmlCanvas.addEventListener("pointerleave", onPointerEvent);
       htmlCanvas.addEventListener("pointercancel", onPointerEvent);
       this._hadListener = true;
     }
@@ -127,9 +127,9 @@ export class PointerManager implements IInput {
     if (this._hadListener) {
       const { _htmlCanvas: htmlCanvas, _onPointerEvent: onPointerEvent } = this;
       htmlCanvas.removeEventListener("pointerdown", onPointerEvent);
-      htmlCanvas.removeEventListener("pointerup", onPointerEvent);
-      htmlCanvas.removeEventListener("pointerout", onPointerEvent);
       htmlCanvas.removeEventListener("pointermove", onPointerEvent);
+      htmlCanvas.removeEventListener("pointerup", onPointerEvent);
+      htmlCanvas.removeEventListener("pointerleave", onPointerEvent);
       htmlCanvas.removeEventListener("pointercancel", onPointerEvent);
       this._hadListener = false;
       this._downList.length = 0;
@@ -150,9 +150,9 @@ export class PointerManager implements IInput {
     if (this._hadListener) {
       const { _htmlCanvas: htmlCanvas, _onPointerEvent: onPointerEvent } = this;
       htmlCanvas.removeEventListener("pointerdown", onPointerEvent);
-      htmlCanvas.removeEventListener("pointerup", onPointerEvent);
-      htmlCanvas.removeEventListener("pointerout", onPointerEvent);
       htmlCanvas.removeEventListener("pointermove", onPointerEvent);
+      htmlCanvas.removeEventListener("pointerup", onPointerEvent);
+      htmlCanvas.removeEventListener("pointerleave", onPointerEvent);
       htmlCanvas.removeEventListener("pointercancel", onPointerEvent);
       this._hadListener = false;
     }
@@ -254,13 +254,7 @@ export class PointerManager implements IInput {
       const normalizedY = (latestEvent.clientY - rect.top) / clientH;
       const currX = normalizedX * canvasW;
       const currY = normalizedY * canvasH;
-      if (currX === position.x && currY === position.y) {
-        pointer.deltaPosition.set(0, 0);
-        pointer.phase = PointerPhase.Stationary;
-      } else {
-        pointer.deltaPosition.set(currX - position.x, currY - position.y);
-        pointer.phase = PointerPhase.Move;
-      }
+      pointer.deltaPosition.set(currX - position.x, currY - position.y);
       position.set(currX, currY);
       pointer._firePointerDrag();
       const rayCastEntity = this._pointerRayCast(normalizedX, normalizedY);
@@ -287,7 +281,10 @@ export class PointerManager implements IInput {
             pointer.phase = PointerPhase.Up;
             pointer._firePointerUpAndClick(rayCastEntity);
             break;
-          case "pointerout":
+          case "pointermove":
+            pointer.phase = PointerPhase.Move;
+            break;
+          case "pointerleave":
           case "pointercancel":
             pointer.phase = PointerPhase.Leave;
             pointer._firePointerExitAndEnter(null);
@@ -345,7 +342,7 @@ export class PointerManager implements IInput {
           case "pointermove":
             pointer.phase = PointerPhase.Move;
             break;
-          case "pointerout":
+          case "pointerleave":
           case "pointercancel":
             pointer.phase = PointerPhase.Leave;
           default:

--- a/packages/core/src/input/pointer/PointerManager.ts
+++ b/packages/core/src/input/pointer/PointerManager.ts
@@ -50,7 +50,7 @@ export class PointerManager implements IInput {
     this._canvas = engine.canvas;
     this._htmlCanvas = htmlCanvas;
     htmlCanvas.oncontextmenu = (event: UIEvent) => {
-      return false;
+      event.cancelable && event.preventDefault();
     };
     this._onPointerEvent = this._onPointerEvent.bind(this);
     this._updatePointerWithPhysics = this._updatePointerWithPhysics.bind(this);
@@ -165,7 +165,6 @@ export class PointerManager implements IInput {
   }
 
   private _onPointerEvent(evt: PointerEvent) {
-    evt.cancelable && evt.preventDefault();
     evt.type === "pointerdown" && this._htmlCanvas.focus();
     this._nativeEvents.push(evt);
   }

--- a/packages/core/src/input/pointer/PointerManager.ts
+++ b/packages/core/src/input/pointer/PointerManager.ts
@@ -112,9 +112,9 @@ export class PointerManager implements IInput {
     if (!this._hadListener) {
       const { _htmlCanvas: htmlCanvas, _onPointerEvent: onPointerEvent } = this;
       htmlCanvas.addEventListener("pointerdown", onPointerEvent);
-      htmlCanvas.addEventListener("pointermove", onPointerEvent);
       htmlCanvas.addEventListener("pointerup", onPointerEvent);
       htmlCanvas.addEventListener("pointerleave", onPointerEvent);
+      htmlCanvas.addEventListener("pointermove", onPointerEvent);
       htmlCanvas.addEventListener("pointercancel", onPointerEvent);
       this._hadListener = true;
     }
@@ -127,9 +127,9 @@ export class PointerManager implements IInput {
     if (this._hadListener) {
       const { _htmlCanvas: htmlCanvas, _onPointerEvent: onPointerEvent } = this;
       htmlCanvas.removeEventListener("pointerdown", onPointerEvent);
-      htmlCanvas.removeEventListener("pointermove", onPointerEvent);
       htmlCanvas.removeEventListener("pointerup", onPointerEvent);
       htmlCanvas.removeEventListener("pointerleave", onPointerEvent);
+      htmlCanvas.removeEventListener("pointermove", onPointerEvent);
       htmlCanvas.removeEventListener("pointercancel", onPointerEvent);
       this._hadListener = false;
       this._downList.length = 0;
@@ -150,9 +150,9 @@ export class PointerManager implements IInput {
     if (this._hadListener) {
       const { _htmlCanvas: htmlCanvas, _onPointerEvent: onPointerEvent } = this;
       htmlCanvas.removeEventListener("pointerdown", onPointerEvent);
-      htmlCanvas.removeEventListener("pointermove", onPointerEvent);
       htmlCanvas.removeEventListener("pointerup", onPointerEvent);
       htmlCanvas.removeEventListener("pointerleave", onPointerEvent);
+      htmlCanvas.removeEventListener("pointermove", onPointerEvent);
       htmlCanvas.removeEventListener("pointercancel", onPointerEvent);
       this._hadListener = false;
     }

--- a/packages/core/src/input/pointer/PointerManager.ts
+++ b/packages/core/src/input/pointer/PointerManager.ts
@@ -49,9 +49,6 @@ export class PointerManager implements IInput {
     this._engine = engine;
     this._canvas = engine.canvas;
     this._htmlCanvas = htmlCanvas;
-    htmlCanvas.oncontextmenu = (event: UIEvent) => {
-      event.cancelable && event.preventDefault();
-    };
     this._onPointerEvent = this._onPointerEvent.bind(this);
     this._updatePointerWithPhysics = this._updatePointerWithPhysics.bind(this);
     this._updatePointerWithoutPhysics = this._updatePointerWithoutPhysics.bind(this);


### PR DESCRIPTION
- change `pointerout` to `pointerleave` (To support replacing target )
- fix pointer `preventDefault` bug
- `oncontextmenu` replace `return false` with `preventDefault` (Follow the principle of least change)
- Fix the wrong held down list caused by the `Meta` under the Mac browser.(https://stackoverflow.com/questions/11818637/why-does-javascript-drop-keyup-events-when-the-metakey-is-pressed-on-mac-browser)